### PR TITLE
Revamp payment success screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -108,3 +108,21 @@
 .scrollbar-stable {
   scrollbar-gutter: stable;
 }
+
+@keyframes success-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.92) translateY(8px);
+  }
+  60% {
+    transform: scale(1.02) translateY(0);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.success-pop {
+  animation: success-pop 0.45s ease-out both;
+}

--- a/components/UI/button.tsx
+++ b/components/UI/button.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { clsx } from "clsx";
+import { cn } from "@/lib/utils";
 
 interface ButtonProps {
   children: React.ReactNode;
@@ -21,7 +21,7 @@ export const Button: React.FC<ButtonProps> = ({
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={clsx(
+      className={cn(
         "relative text-secondary rounded-xl transition-all duration-200 focus:outline-none focus:ring-4 focus:ring-blue-500/50 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100",
         "bg-accent shadow-lg hover:shadow-xl hover:opacity-80",
         "px-8 py-4 text-lg",

--- a/components/UI/icons.tsx
+++ b/components/UI/icons.tsx
@@ -1,0 +1,34 @@
+interface IconProps {
+  className?: string;
+}
+
+export const CopyIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  </svg>
+);
+
+export const CheckIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+);

--- a/components/card-payment.tsx
+++ b/components/card-payment.tsx
@@ -8,6 +8,8 @@ import {
 import { loadStripe } from "@stripe/stripe-js";
 import { Button } from "@/components/UI/button";
 import { TabHelper } from "@/components/UI/tab-helper";
+import { copyToClipboard } from "@/lib/utils";
+import { CheckIcon, CopyIcon } from "@/components/UI/icons";
 
 interface CardPaymentProps {
   stripePublishableKey: string | null;
@@ -16,6 +18,8 @@ interface CardPaymentProps {
   onError: (error: string) => void;
 }
 
+const TEST_CARD_NUMBER = "4242 4242 4242 4242";
+
 const StripeForm: React.FC<{
   onSuccess: () => void;
   onError: (error: string) => void;
@@ -23,6 +27,14 @@ const StripeForm: React.FC<{
   const stripe = useStripe();
   const elements = useElements();
   const [isProcessing, setIsProcessing] = useState(false);
+  const [cardCopied, setCardCopied] = useState(false);
+
+  const handleCopyCard = async () => {
+    if (await copyToClipboard(TEST_CARD_NUMBER.replace(/\s/g, ""))) {
+      setCardCopied(true);
+      setTimeout(() => setCardCopied(false), 2000);
+    }
+  };
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -60,13 +72,22 @@ const StripeForm: React.FC<{
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <TabHelper title="TEST CARD">
-        <input
-          type="text"
-          value="4242 4242 4242 4242"
-          disabled
-          readOnly
-          className="w-full"
-        />
+        <div className="flex items-center justify-between gap-2">
+          <span>{TEST_CARD_NUMBER}</span>
+          <button
+            type="button"
+            onClick={handleCopyCard}
+            className="p-1 cursor-pointer text-primary/80 hover:text-primary transition-colors"
+            title="Copy test card number"
+            aria-label="Copy test card number"
+          >
+            {cardCopied ? (
+              <CheckIcon className="w-[18px] h-[18px] text-green-400" />
+            ) : (
+              <CopyIcon className="w-[18px] h-[18px]" />
+            )}
+          </button>
+        </div>
       </TabHelper>
       <PaymentElement className="w-full" />
       <Button

--- a/components/checkout-dialog.tsx
+++ b/components/checkout-dialog.tsx
@@ -5,6 +5,7 @@ import { collectionId, createOrder, updateOrder, pollOrder } from "@/lib/api";
 import { CardPayment } from "./card-payment";
 import { CryptoPayment } from "./crypto-payment";
 import { CheckoutStatus } from "./checkout-status";
+import { CheckoutSuccess } from "./checkout-success";
 import { useAccount } from "wagmi";
 import { PaymentMethodButton } from "@/components/UI/payment-method-button";
 
@@ -154,6 +155,7 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({
   if (!isOpen) return null;
 
   const checkoutStatus = getCheckoutStatus();
+  const isSuccess = checkoutStatus?.status === "success";
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
@@ -161,12 +163,20 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-primary/60 hover:text-primary text-2xl"
+          className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full border border-accent/40 bg-accent-foreground text-primary/80 hover:text-primary hover:border-accent transition-colors text-lg leading-none"
           type="button"
+          aria-label="Close checkout"
         >
           ×
         </button>
 
+        {/* Success screen replaces the whole checkout flow */}
+        {isSuccess && order ? (
+          <div className="flex-1 overflow-y-auto overflow-x-hidden pr-4 -mr-4 scrollbar-stable">
+            <CheckoutSuccess order={order} />
+          </div>
+        ) : (
+          <>
         {/* Selected weapon info */}
         <div className="flex items-center justify-between">
           <div>
@@ -279,6 +289,8 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({
             </>
           )}
         </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/components/checkout-status.tsx
+++ b/components/checkout-status.tsx
@@ -16,27 +16,5 @@ export const CheckoutStatus: React.FC<CheckoutStatusProps> = ({
     );
   }
 
-  if (status === "success") {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-4">
-        <div className="w-16 h-16 bg-green-500/20 rounded-full flex items-center justify-center">
-          <svg
-            className="w-8 h-8 text-green-500"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-            aria-hidden="true"
-          >
-            <path
-              fillRule="evenodd"
-              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </div>
-        <p className="text-white text-center font-semibold">{message}</p>
-      </div>
-    );
-  }
-
   return null;
 };

--- a/components/checkout-success.tsx
+++ b/components/checkout-success.tsx
@@ -1,0 +1,209 @@
+import Image from "next/image";
+import { useState } from "react";
+import type { Order } from "@/types/api";
+import { getNftUrl, getTransactionUrl } from "@/lib/explorer";
+import { copyToClipboard } from "@/lib/utils";
+import { CheckIcon, CopyIcon } from "@/components/UI/icons";
+import { Button } from "@/components/UI/button";
+
+interface CheckoutSuccessProps {
+  order: Order;
+}
+
+const DOCS_URL = "https://docs.crossmint.com/payments/headless/overview";
+const CONTACT_URL = "https://www.crossmint.com/contact";
+
+const ExternalLinkIcon = () => (
+  <svg
+    className="w-4 h-4"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+    />
+  </svg>
+);
+
+const BuildStep: React.FC = () => (
+  <div className="flex flex-col items-center gap-6 py-6 text-center success-pop">
+    <div className="w-16 h-16 rounded-full bg-accent-foreground border border-accent/40 flex items-center justify-center">
+      <svg
+        className="w-8 h-8 text-accent"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"
+        />
+      </svg>
+    </div>
+
+    <div className="flex flex-col items-center gap-2">
+      <h3 className="text-primary text-3xl font-['BreatheFireIII'] tracking-wide">
+        BUILD YOUR OWN
+      </h3>
+      <p className="text-primary/70 max-w-sm">
+        This demo runs on Crossmint&apos;s headless checkout API. Add the same
+        flow to your app in minutes.
+      </p>
+    </div>
+
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full">
+      <Button
+        onClick={() => window.open(DOCS_URL, "_blank", "noopener")}
+        className="w-full px-4"
+      >
+        READ THE DOCS
+      </Button>
+      <Button
+        onClick={() => window.open(CONTACT_URL, "_blank", "noopener")}
+        className="w-full px-4"
+      >
+        CONTACT SALES
+      </Button>
+    </div>
+  </div>
+);
+
+export const CheckoutSuccess: React.FC<CheckoutSuccessProps> = ({
+  order,
+}) => {
+  const [step, setStep] = useState<"receipt" | "build">("receipt");
+  const [copied, setCopied] = useState(false);
+
+  const lineItem = order.lineItems?.[0];
+  const token = lineItem?.delivery?.tokens?.[0];
+  const nftUrl = getNftUrl(
+    lineItem?.chain,
+    token?.contractAddress,
+    token?.tokenId
+  );
+  const txUrl = getTransactionUrl(lineItem?.chain, lineItem?.delivery?.txId);
+  const explorerUrl = nftUrl ?? txUrl;
+  const totalPrice = order.quote?.totalPrice;
+
+  const handleCopyOrderId = async () => {
+    if (await copyToClipboard(order.orderId)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  if (step === "build") {
+    return <BuildStep />;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-2 success-pop">
+      {/* Animated check; top margin leaves room for the ping halo (2x scale) */}
+      <div className="relative mt-12">
+        <div className="absolute inset-0 rounded-full bg-green-400/40 animate-ping" />
+        <div className="relative w-20 h-20 rounded-full bg-gradient-to-b from-green-400 to-green-600 flex items-center justify-center shadow-lg shadow-green-500/40">
+          <svg
+            className="w-10 h-10 text-white"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={3}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4.5 12.75l6 6 9-13.5"
+            />
+          </svg>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h3 className="text-primary text-3xl font-['BreatheFireIII'] tracking-wide">
+          PAYMENT SUCCESSFUL
+        </h3>
+        <p className="text-primary/70">
+          The God Sword is yours! It has been delivered on-chain.
+        </p>
+      </div>
+
+      {/* Receipt card */}
+      <div className="w-full rounded-xl border border-accent/40 bg-accent-foreground p-4 flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <div className="bg-card-foreground rounded-lg p-2">
+            <Image
+              src="/sword.svg"
+              alt="God Sword"
+              width={40}
+              height={40}
+              className="w-10 h-10 object-contain"
+            />
+          </div>
+          <div className="flex-1">
+            <p className="text-primary font-semibold">God Sword</p>
+            <p className="text-primary/60 text-sm">Delivered ✓</p>
+          </div>
+        </div>
+
+        <div className="border-t border-accent/20 pt-3 flex flex-col gap-2 text-sm">
+          {totalPrice && (
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-primary/60">Total paid</span>
+              <span className="text-primary font-semibold">
+                ${totalPrice.amount}{" "}
+                <span className="text-primary/60 font-normal uppercase">
+                  {totalPrice.currency}
+                </span>
+              </span>
+            </div>
+          )}
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-primary/60">Order ID</span>
+            <button
+              type="button"
+              onClick={handleCopyOrderId}
+              className="flex items-center gap-1.5 text-primary/90 hover:text-primary font-mono"
+              title="Copy order ID"
+            >
+              {order.orderId.slice(0, 8)}…{order.orderId.slice(-4)}
+              {copied ? (
+                <CheckIcon className="w-3.5 h-3.5 text-green-400" />
+              ) : (
+                <CopyIcon className="w-3.5 h-3.5" />
+              )}
+            </button>
+          </div>
+          {explorerUrl && (
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-primary/60">
+                {nftUrl ? "Your NFT" : "Transaction"}
+              </span>
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-accent hover:underline underline-offset-4"
+              >
+                View on block explorer
+                <ExternalLinkIcon />
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Button onClick={() => setStep("build")} className="w-full">
+        CONTINUE
+      </Button>
+    </div>
+  );
+};

--- a/lib/explorer.ts
+++ b/lib/explorer.ts
@@ -1,0 +1,28 @@
+const EXPLORER_BASE_URLS: Record<string, string> = {
+  ethereum: "https://etherscan.io",
+  "ethereum-sepolia": "https://sepolia.etherscan.io",
+  polygon: "https://polygonscan.com",
+  "polygon-amoy": "https://amoy.polygonscan.com",
+  base: "https://basescan.org",
+  "base-sepolia": "https://sepolia.basescan.org",
+  arbitrum: "https://arbiscan.io",
+  "arbitrum-sepolia": "https://sepolia.arbiscan.io",
+  optimism: "https://optimistic.etherscan.io",
+  "optimism-sepolia": "https://sepolia-optimism.etherscan.io",
+};
+
+export const getTransactionUrl = (chain?: string, txId?: string) => {
+  if (!chain || !txId) return null;
+  const baseUrl = EXPLORER_BASE_URLS[chain];
+  return baseUrl ? `${baseUrl}/tx/${txId}` : null;
+};
+
+export const getNftUrl = (
+  chain?: string,
+  contractAddress?: string,
+  tokenId?: string
+) => {
+  if (!chain || !contractAddress || !tokenId) return null;
+  const baseUrl = EXPLORER_BASE_URLS[chain];
+  return baseUrl ? `${baseUrl}/nft/${contractAddress}/${tokenId}` : null;
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,25 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Fall back for browsers/contexts without async clipboard permission
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      return document.execCommand("copy");
+    } catch {
+      return false;
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -22,6 +22,18 @@ export type Order = {
     callData: {
       totalPrice: string;
     };
+    chain?: string;
+    delivery?: {
+      status?: string;
+      txId?: string;
+      recipient?: {
+        walletAddress?: string;
+      };
+      tokens?: {
+        contractAddress?: string;
+        tokenId?: string;
+      }[];
+    };
   }[];
   quote: {
     totalPrice: {


### PR DESCRIPTION
## What

The success state previously kept the payment method tabs visible and showed only a small check + "Payment successful! 🎉" line. This PR turns it into a proper post-purchase experience:

**Step 1 — Receipt**
- Payment tabs and order summary header are hidden once payment completes
- Animated success check (halo has headroom, no clipping)
- Receipt card: item + "Delivered ✓", total paid, copyable order ID, and a **View on block explorer** link pointing at the delivered NFT (built from `lineItems[0].delivery` chain/txId/token via the new `lib/explorer.ts`, tx-link fallback when no token is returned)
- Single CONTINUE button

**Step 2 — Build your own**
- Dedicated conversion screen with two equal-weight CTAs: **Read the Docs** (headless checkout overview) and **Contact Sales**

**Other improvements**
- Copy button on the `4242 4242 4242 4242` test card number (clipboard API with `execCommand` fallback)
- Close (×) is now a visible circled button
- Inline lucide copy/check icons so they inherit text color instead of rendering black
- `Button` now merges classes with `tailwind-merge` so `className` overrides resolve predictably

## Testing

- 5 full card payments on staging end-to-end (Stripe test card → order polling → on-chain delivery), verified with Playwright
- Explorer NFT link verified against Base Sepolia RPC (`ownerOf`/`tokenURI`)
- Copy buttons verified (icon flip + clipboard contents)
- Mobile (375px): CTA grid stacks to one column, no overflow
- `tsc --noEmit` clean, browser console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/headless-checkout-quickstart/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->