### PR TITLE
Point the contact sales CTA at /contact/sales

### DIFF
--- a/components/checkout-success.tsx
+++ b/components/checkout-success.tsx
@@ -11,7 +11,7 @@ interface CheckoutSuccessProps {
 }
 
 const DOCS_URL = "https://docs.crossmint.com/payments/headless/overview";
-const CONTACT_URL = "https://www.crossmint.com/contact";
+const CONTACT_URL = "https://www.crossmint.com/contact/sales";
 
 const ExternalLinkIcon = () => (
   <svg


### PR DESCRIPTION
Updates the CONTACT SALES button on the post-purchase "Build your own" screen to link to https://www.crossmint.com/contact/sales (verified live, returns 200) instead of the generic /contact page.

One-line change to `CONTACT_URL` in `components/checkout-success.tsx`. Independent of #29 — no conflicts (that PR doesn't touch this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/headless-checkout-quickstart/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->