### PR TITLE
fix(DVRL-1362): use same stub modules for optional native deps in dev and prod

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,14 @@
+import path from "path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@react-native-async-storage/async-storage": false,
-      "pino-pretty": false,
+      "@react-native-async-storage/async-storage": path.resolve(
+        "./lib/stubs/async-storage"
+      ),
+      "pino-pretty": path.resolve("./lib/stubs/pino-pretty"),
     };
     return config;
   },


### PR DESCRIPTION
## Summary

Follow-up to the Basis Theory migration PR: the previous fix added Turbopack `resolveAlias` stubs for the optional native packages `@react-native-async-storage/async-storage` and `pino-pretty`, but kept the webpack production aliases pointing to `false`. Webpack resolves `false` to an empty module, while the dev stubs expose callable APIs, so the same code path could behave differently in development and production.

This PR makes both bundlers resolve the same stub modules:

- `next.config.ts`:
  ```ts
  webpack: (config) => {
    config.resolve.alias = {
      ...config.resolve.alias,
      "@react-native-async-storage/async-storage": path.resolve("./lib/stubs/async-storage"),
      "pino-pretty": path.resolve("./lib/stubs/pino-pretty"),
    };
    return config;
  },
  experimental: {
    turbo: {
      resolveAlias: {
        "@react-native-async-storage/async-storage": "./lib/stubs/async-storage",
        "pino-pretty": "./lib/stubs/pino-pretty",
      },
    },
  },
  ```

The stubs in `lib/stubs/` provide no-op implementations, keeping the demo build clean while avoiding runtime divergence between `pnpm dev --turbopack` and `pnpm build`.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/51b574230e65494fbc506e0bbd2122ab
Requested by: @fedemint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/headless-checkout-quickstart/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->